### PR TITLE
Feat/completar crud

### DIFF
--- a/back/src/main/java/com/petcare/back/controller/OwnerController.java
+++ b/back/src/main/java/com/petcare/back/controller/OwnerController.java
@@ -35,6 +35,7 @@ public class OwnerController {
     private final PlanService planService;
     private final BookingService bookingService;
     private final UserService userService;
+    private final OfferingService offeringService;
 
     @Operation(
             summary = "Registrar mascota",
@@ -128,6 +129,46 @@ public class OwnerController {
     @GetMapping("/list/combo")
     public ResponseEntity<List<ComboOfferingResponseDTO>> findAll() {
         return ResponseEntity.ok(comboOfferingService.findAll());
+    }
+
+    @Operation(
+            summary = "Listar combos públicos de un profesional",
+            description = "Devuelve todos los combos activos ofrecidos por el profesional indicado, visibles para dueños."
+    )
+
+    @GetMapping("/public/{sitterId}/combos")
+    public ResponseEntity<?> verCombos(@PathVariable Long sitterId) {
+        try {
+            List<ComboOfferingResponseDTO> combos = comboOfferingService.getPublicCombosBySitter(sitterId);
+            return ResponseEntity.ok(Map.of(
+                    "status", "success",
+                    "data", combos
+            ));
+        } catch (MyException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "status", "error",
+                    "message", e.getMessage()
+            ));
+        }
+    }
+    @Operation(
+            summary = "Listar servicios individuales de un profesional",
+            description = "Devuelve todos los servicios activos ofrecidos por el profesional indicado, visibles para dueños."
+    )
+    @GetMapping("/public/{sitterId}/offerings")
+    public ResponseEntity<?> verOfferings(@PathVariable Long sitterId) {
+        try {
+            List<OfferingResponseDTO> offerings = offeringService.getPublicOfferingsBySitter(sitterId);
+            return ResponseEntity.ok(Map.of(
+                    "status", "success",
+                    "data", offerings
+            ));
+        } catch (MyException e) {
+            return ResponseEntity.badRequest().body(Map.of(
+                    "status", "error",
+                    "message", e.getMessage()
+            ));
+        }
     }
 
     @Operation(

--- a/back/src/main/java/com/petcare/back/domain/dto/request/ComboOfferingUpdateDTO.java
+++ b/back/src/main/java/com/petcare/back/domain/dto/request/ComboOfferingUpdateDTO.java
@@ -1,0 +1,14 @@
+package com.petcare.back.domain.dto.request;
+
+import com.petcare.back.domain.enumerated.ComboEnum;
+import jakarta.validation.constraints.DecimalMin;
+
+import java.util.List;
+
+public record ComboOfferingUpdateDTO(
+        ComboEnum name,
+        String description,
+        @DecimalMin("0.0") Double discount,
+        List<Long> offeringIds
+) {
+}

--- a/back/src/main/java/com/petcare/back/domain/dto/response/OfferingResponseDTO.java
+++ b/back/src/main/java/com/petcare/back/domain/dto/response/OfferingResponseDTO.java
@@ -6,10 +6,11 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record OfferingResponseDTO(Long id,
-                                  String name,
-                                  String description,
-                                  BigDecimal basePrice,
-                                  List<PetTypeEnum> applicablePetTypes,
-                                  LocalDateTime createdAt) {
+public record OfferingResponseDTO(
+        Long id,
+        String name,
+        String description,
+        BigDecimal basePrice,
+        List<PetTypeEnum> applicablePetTypes
+) {
 }

--- a/back/src/main/java/com/petcare/back/repository/ComboOfferingRepository.java
+++ b/back/src/main/java/com/petcare/back/repository/ComboOfferingRepository.java
@@ -2,10 +2,15 @@ package com.petcare.back.repository;
 
 import com.petcare.back.domain.entity.ComboOffering;
 import com.petcare.back.domain.enumerated.ComboEnum;
+import io.micrometer.common.KeyValues;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ComboOfferingRepository extends JpaRepository<ComboOffering, Long> {
     boolean existsByName(ComboEnum name);
+
+    List<ComboOffering> findBySitterId(Long id);
 }

--- a/back/src/main/java/com/petcare/back/repository/OfferingRepository.java
+++ b/back/src/main/java/com/petcare/back/repository/OfferingRepository.java
@@ -3,6 +3,7 @@ package com.petcare.back.repository;
 import com.petcare.back.domain.entity.Offering;
 import com.petcare.back.domain.enumerated.OfferingEnum;
 import com.petcare.back.domain.enumerated.PetTypeEnum;
+import io.micrometer.common.KeyValues;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,4 +14,8 @@ import java.util.Optional;
 public interface OfferingRepository extends JpaRepository<Offering, Long> {
 
     List<Offering> findByName(OfferingEnum name);
+
+    List<Offering> findBySitterId(Long id);
+
+    List<Offering> findBySitterIdAndActiveTrue(Long sitterId);
 }


### PR DESCRIPTION
Este PR implementa el CRUD completo para servicios individuales (Offering) y combos de servicios (ComboOffering), incluyendo validaciones específicas, control de acceso por rol, y endpoints diferenciados para profesionales (sitter) y dueños (owner).

🔧 Offering (servicio individual)
- Endpoint POST /register/offering: creación de servicios por profesionales verificados.
- Validaciones por rol (ProfessionalRoleEnum), verificación de perfil y lógica de negocio.
- Endpoint PUT /offering/{id}: actualización parcial con control de ownership.
- Endpoint DELETE /offering/{id}: eliminación lógica (active = false).
- Endpoint GET /offering/my: listado de servicios propios del sitter.
- Endpoint GET /public/{sitterId}/offerings: visualización pública para dueños.

🧩 ComboOffering (combo de servicios)
- Endpoint POST /register/combo: creación de combos con múltiples servicios propios.
- Validación de ownership sobre los servicios incluidos.
- Evaluación de advertencias (WarningComboEvaluator) para inconsistencias.
- Endpoint PUT /combo/{id}: actualización parcial de nombre, descripción, descuento y servicios.
- Endpoint DELETE /combo/{id}: eliminación lógica.
- Endpoint GET /my/combos: listado de combos propios del sitter.
- Endpoint GET /public/{sitterId}/combos: visualización pública para dueños.